### PR TITLE
chore: :wrench: need quotes around text that uses `:` in `_quarto.yml`

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -9,13 +9,15 @@ website:
     pinned: true
     left:
       - index.qmd 
-      - sidebar:wp1
-      - text: WP2: Risk Prediction
-        href: wp2.qmd 
-      - text: WP3: Heterogeneity
-        href: wp3.qmd 
-      - text: WP4: Intervention Development
-        href: wp4.qmd 
+      - text: "Work packages"
+        menu: 
+        - sidebar:wp1
+        - text: "WP2: Risk Prediction"
+          href: wp2.qmd 
+        - text: "WP3: Heterogeneity"
+          href: wp3.qmd 
+        - text: "WP4: Intervention Development"
+          href: wp4.qmd 
       - text: Who We Are
         href: who-we-are.qmd
     tools:


### PR DESCRIPTION
Whenever text is added to a field in the `_quarto.yml` file that includes a `:`, Quarto interprets that as a new field. So you need to include quotes around it to escape its interpretation.

I also converted it into a menu list, since the full titles across the top navbar looked bad when rendered on the website.