### PR TITLE
Updated Danish participant page content

### DIFF
--- a/da/participant-clinical.qmd
+++ b/da/participant-clinical.qmd
@@ -4,7 +4,7 @@ title: "Klinisk undersøgelse"
 
 ## Hvad indebærer de kliniske undersøgelser?
 
-Nogle deltagere vil blive inviteret til at deltage i en klinisk undersøgelse på et Steno Diabetes Center. Formålet er at etablere en ny klinisk kohorte med detaljerede helbredsmålinger for at forbedre forståelsen af tidlige biologiske ændringer relateret til risikoen for diabetes.
+Nogle deltagere vil blive inviteret til at deltage i en klinisk undersøgelse på et Steno Diabetes Center. Formålet er at etablere en ny klinisk kohorte med detaljerede helbredsmålinger for at forbedre forståelsen af tidlige biologiske og livsstilsrelaterede faktorer forbundet med risikoen for type 2-diabetes.
 
 Undersøgelsen varer cirka 4 timer og kan omfatte:
 
@@ -13,9 +13,9 @@ Undersøgelsen varer cirka 4 timer og kan omfatte:
 - En glukosebelastningstest
 - Måling af leverfedt
 - Blodtryks- og hjerte-kar-målinger
-- Vurdering af fysisk aktivitet
+- Aktivitetsure og glukosesensorer
 - Opbevaring af biologiske prøver i en forskningsbiobank
 
-Disse undersøgelser hjælper forskerne med at forstå forskelle i diabetesrisiko mellem personer og identificere tidlige biologiske markører for sygdomsudvikling.
+Disse undersøgelser hjælper forskerne med bedre at forstå, hvorfor nogle mennesker udvikler type 2-diabetes, mens andre ikke gør.
 
 Deltagelse i den kliniske undersøgelse er frivillig og kræver særskilt samtykke.

--- a/da/participant-clinical.qmd
+++ b/da/participant-clinical.qmd
@@ -13,7 +13,7 @@ Undersøgelsen varer cirka 4 timer og kan omfatte:
 - En glukosebelastningstest
 - Måling af leverfedt
 - Blodtryks- og hjerte-kar-målinger
-- Aktivitetsure og glukosesensorer
+- Aktivitetsmåler og glukosesensor til brug derhjemme i 14 dage efter besøget
 - Opbevaring af biologiske prøver i en forskningsbiobank
 
 Disse undersøgelser hjælper forskerne med bedre at forstå, hvorfor nogle mennesker udvikler type 2-diabetes, mens andre ikke gør.

--- a/da/participant-questionnaire.qmd
+++ b/da/participant-questionnaire.qmd
@@ -4,18 +4,56 @@ title: "Spørgeskema"
 
 ## Hvad indebærer spørgeskemaet?
 
-Spørgeskemaet indsamler information om faktorer, der kan påvirke risikoen for at udvikle type 2-diabetes.
+I spørgeskemaet beder vi dig besvare en række spørgsmål om forhold, der
+kan have betydning for risikoen for at udvikle type 2-diabetes. Det
+tager cirka 30 minutter at udfylde spørgeskemaet.
 
 Spørgeskemaet indeholder spørgsmål om:
 
-- Dit generelle helbred og din sygehistorie
-- Livsstil, herunder kost, fysisk aktivitet og søvn
-- Mental trivsel, stress og livskvalitet
+- Dit generelle helbred og sygdomshistorie
+- Kost, motion, alkohol og rygning
+- Søvn, stress, trivsel og livskvalitet
 - Sociale og arbejdsrelaterede forhold
+- Uddannelse, arbejde og fritid
 - Familiær sygdomshistorik
 
-Spørgeskemaet udfyldes online via et sikkert system, og du kan besvare det i dit eget tempo.
+## Hvad er formålet med spørgeskemaet?
 
-Dine besvarelser kan blive koblet med oplysninger fra nationale sundhedsregistre, såsom diagnoser og laboratoriesvar. Dette hjælper forskerne med bedre at forstå risikoen for diabetes og identificere forskellige risikoprofiler.
+Type 2-diabetes diagnosticeres oftest ud fra en blodprøve, der måler
+langtidsblodsukkeret (HbA1c). Har man et langtidsblodsukkerniveau over
+en bestemt grænse, får man diagnosen type 2-diabetes. Personer uden
+diabetes kan dog stadig have en øget risiko for at udvikle sygdommen, da
+risikoen ikke kun afhænger af blodsukkerniveauet, men også af en række
+helbreds-, livsstils- og sociale forhold. Det er netop disse forhold, vi
+gerne vil blive klogere på.
 
-Alle oplysninger behandles fortroligt og i overensstemmelse med gældende regler for databeskyttelse.
+Ved at besvare dette spørgeskema hjælper du os med at forstå, hvilke
+faktorer der er forbundet med øget risiko for type 2-diabetes, og
+hvordan vi kan forebygge sygdommen mere effektivt i fremtiden.
+
+## Hvem bliver inviteret?
+
+Vi inviterer i alt cirka 60.000 personer mellem 40 og 50 år til at
+udfylde spørgeskemaet. Blandt dem der svarer, vil vi senere invitere
+cirka 1.000 personer til en mere grundig undersøgelse på et teststed.
+Bemærk, at det kun er et lille antal deltagere, der bliver udvalgt til
+dette. Til sidst i spørgeskemaet spørger vi derfor, om vi må kontakte
+dig med et tilbud om at deltage i de videre undersøgelser. Det er altid
+frivilligt at deltage og selvom du har svaret ja til spørgeskemaet og
+til at blive kontaktet, kan du altid svare nej til de videre
+undersøgelser.
+
+## Databeskyttelse og fortrolighed
+
+Spørgeskemaet udfyldes online i et sikkert system, og du kan udfylde det
+i dit eget tempo.
+
+Dine besvarelser kan blive koblet med oplysninger fra nationale
+sundhedsregistre, såsom diagnoser og laboratoriesvar. Dette hjælper
+forskerne med bedre at forstå risikoen for diabetes og identificere
+forskellige risikoprofiler.
+
+Alle oplysninger behandles fortroligt og i overensstemmelse med gældende
+regler for databeskyttelse. Personlige oplysninger opbevares sikkert og
+adskilt fra forskningsdata, og resultater offentliggøres altid anonymt,
+så ingen kan genkendes.

--- a/da/participant-questionnaire.qmd
+++ b/da/participant-questionnaire.qmd
@@ -27,9 +27,11 @@ risikoen ikke kun afhænger af blodsukkerniveauet, men også af en række
 helbreds-, livsstils- og sociale forhold. Det er netop disse forhold, vi
 gerne vil blive klogere på.
 
-Ved at besvare dette spørgeskema hjælper du os med at forstå, hvilke
-faktorer der er forbundet med øget risiko for type 2-diabetes, og
-hvordan vi kan forebygge sygdommen mere effektivt i fremtiden.
+Ved at besvare dette spørgeskema hjælper du os med at blive klogere på,
+hvilke faktorer der er forbundet med øget risiko for type 2-diabetes, og
+hvorfor nogle mennesker har større risiko end andre. Det er viden, vi
+har brug for for at kunne forebygge sygdommen mere effektivt i
+fremtiden.
 
 ## Hvem bliver inviteret?
 
@@ -49,11 +51,13 @@ Spørgeskemaet udfyldes online i et sikkert system, og du kan udfylde det
 i dit eget tempo.
 
 Dine besvarelser kan blive koblet med oplysninger fra nationale
-sundhedsregistre, såsom diagnoser og laboratoriesvar. Dette hjælper
-forskerne med bedre at forstå risikoen for diabetes og identificere
-forskellige risikoprofiler.
+sundhedsregistre, såsom diagnoser og laboratoriesvar.
 
 Alle oplysninger behandles fortroligt og i overensstemmelse med gældende
 regler for databeskyttelse. Personlige oplysninger opbevares sikkert og
 adskilt fra forskningsdata, og resultater offentliggøres altid anonymt,
 så ingen kan genkendes.
+
+Du kan læse mere om dine rettigheder som deltager i sundhedvidenskabelig
+forskning
+[her](https://www.videnskabsetik.dk/deltagelse-i-kliniske-forsoeg/dine-rettigheder-som-forsoegsperson)

--- a/da/participant-questionnaire.qmd
+++ b/da/participant-questionnaire.qmd
@@ -58,6 +58,6 @@ regler for databeskyttelse. Personlige oplysninger opbevares sikkert og
 adskilt fra forskningsdata, og resultater offentliggøres altid anonymt,
 så ingen kan genkendes.
 
-Du kan læse mere om dine rettigheder som deltager i sundhedvidenskabelig
+Du kan læse mere om dine rettigheder some deltager i sundhedvidenskabelig
 forskning
 [her](https://www.videnskabsetik.dk/deltagelse-i-kliniske-forsoeg/dine-rettigheder-som-forsoegsperson)


### PR DESCRIPTION
## Description

This PR primarily includes updates to the Danish participant questionnaire page (da/participant-questionnaire.qmd). Changes are for now limited to the Danish version, as the content will first be translated to the other languages once we have agreed on what should be written.

We might consider adding a new subpage under each language's participant section called "Contact information", which would appear in the left sidebar below "Clinical examination". This page could include the project contact email: [dp-next@rm.dk](mailto:dp-next@rm.dk). I could not quite figure out how this subpage is added in the current code. It would be great if one of the others could give it a try

This PR needs a quick review.
