### PR TITLE
Enable page navigation for events listing

### DIFF
--- a/events/index.qmd
+++ b/events/index.qmd
@@ -5,6 +5,7 @@ listing:
     - "2026-03-18"
     - "2026-09-24"
   sort: "date desc"
+page-navigation: true
 ---
 This page contains a listing of events that DP-Next hosts or runs. Below is a list
 of these events, ordered by date.


### PR DESCRIPTION
## Description

Added page-navigation: true to events/index.qmd to ensure the navbar remains consistent when tapping on "events" in the navbar.

This PR needs a quick review.
